### PR TITLE
Fix unexpected default style mutation

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class Markdown extends Component {
         const outputResult = this.reactOutput(parseTree);
 
         const defaultStyles = this.props.useDefaultStyles && styles ? styles : {};
-        const _styles = StyleSheet.create(Object.assign(defaultStyles, this.props.markdownStyles));
+        const _styles = StyleSheet.create(Object.assign({}, defaultStyles, this.props.markdownStyles));
 
         this.state = {
             syntaxTree: outputResult,


### PR DESCRIPTION
Fix issue where when useDefaultStyles is true and markdownStyles is also supplied the defaultStyles are permanently mutated for all instances of the component.