### PR TITLE
Merge default styles with custom styles for all text nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ class Markdown extends Component {
 
         const { styles } = this.state;
 
-        let style = (extras && extras.style) ? [styles.text].concat(extras.style) : styles.text;
+        let style = StyleSheet.flatten(extras && extras.style ? [styles.text].concat(extras.style) : styles.text);
 
         if (node.props) {
             return (


### PR DESCRIPTION
Case:
Currently, we can't use user-defined styles for all text nodes, because the array created in `renderText` is invalid.

Solution:
We can use `StyleSheet.flatten` to merge `extras.style` and default text style.

Tested on both Android & iOS
