### PR TITLE
Regular Expression Denial of Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "license": "MIT",
     "dependencies": {
-        "simple-markdown": "^0.4.4"
+        "simple-markdown": "^0.5.2"
     },
     "peerDependencies": {
         "react-native": "*"


### PR DESCRIPTION
The simple-markdown 0.4.x is vulnerable to a [Regular Expression Denial of Service](https://www.npmjs.com/advisories/1147).