### PR TITLE
Convert to function component with hooks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["react-native"]
-}

--- a/Utils.js
+++ b/Utils.js
@@ -8,10 +8,11 @@ const Utils = {
             typeof nodes[i].hasOwnProperty === 'function' &&
             Object.prototype.hasOwnProperty.call(nodes[i], 'type') &&
             typeof nodes[i].type.hasOwnProperty === 'function' &&
-            Object.prototype.hasOwnProperty.call(
-              (nodes[i].type, 'displayName') ||
-                Object.prototype.hasOwnProperty.call(nodes[i].type, 'name')
-            )
+            (Object.prototype.hasOwnProperty.call(
+              nodes[i].type,
+              'displayName'
+            ) ||
+              Object.prototype.hasOwnProperty.call(nodes[i].type, 'name'))
           ) {
             if (
               nodes[i].type.displayName !== 'Text' &&

--- a/Utils.js
+++ b/Utils.js
@@ -1,64 +1,70 @@
 const Utils = {
-    isTextOnly(nodes) {
-        try {
-            if (nodes.length) {
-                for (let i = 0; i < nodes.length; i++) {
-                    if (nodes[i] &&
-                        typeof nodes[i].hasOwnProperty === 'function' &&
-                        nodes[i].hasOwnProperty('type') &&
-                        typeof nodes[i].type.hasOwnProperty === 'function' &&
-                        (
-                            nodes[i].type.hasOwnProperty('displayName') ||
-                            nodes[i].type.hasOwnProperty('name')
-                        )
-                    ) {
-                        if (nodes[i].type.displayName !== 'Text' && nodes[i].type.name !== 'Text') {
-                            return false;
-                        }
-                    } else {
-                        return false;
-                    }
-                }
+  isTextOnly (nodes) {
+    try {
+      if (nodes.length) {
+        for (let i = 0; i < nodes.length; i++) {
+          if (
+            nodes[i] &&
+            typeof nodes[i].hasOwnProperty === 'function' &&
+            Object.prototype.hasOwnProperty.call(nodes[i], 'type') &&
+            typeof nodes[i].type.hasOwnProperty === 'function' &&
+            Object.prototype.hasOwnProperty.call(
+              (nodes[i].type, 'displayName') ||
+                Object.prototype.hasOwnProperty.call(nodes[i].type, 'name')
+            )
+          ) {
+            if (
+              nodes[i].type.displayName !== 'Text' &&
+              nodes[i].type.name !== 'Text'
+            ) {
+              return false
             }
-        } catch(e) {
-            return false;
+          } else {
+            return false
+          }
         }
-
-        // It's a miracle, I guess we're text only
-        return true;
-    },
-
-    concatStyles: function concatStyles(extras, newStyle) {
-        let newExtras;
-        if (extras) {
-            newExtras = JSON.parse(JSON.stringify(extras));
-
-            if (extras.style) {
-                newExtras.style.push(newStyle);
-            } else {
-                newExtras.style = [newStyle];
-            }
-        } else {
-            newExtras = {
-                style: [newStyle]
-            };
-        }
-        return newExtras;
-    },
-
-    logDebug: function logDebug(nodeTree, level = 0) {
-        for (let i = 0; i < nodeTree.length; i++) {
-            const node = nodeTree[i];
-
-            if (node) {
-                let prefix = Array(level).join('-');
-                console.log(prefix + '> ' + node.key + ', NODE TYPE: ' + node.type.displayName);
-                if (Array.isArray(node.props.children)) {
-                    this.logDebug(node.props.children, level + 1);
-                }
-            }
-        }
+      }
+    } catch (e) {
+      return false
     }
+
+    // It's a miracle, I guess we're text only
+    return true
+  },
+
+  concatStyles: function concatStyles (extras, newStyle) {
+    let newExtras
+    if (extras) {
+      newExtras = JSON.parse(JSON.stringify(extras))
+
+      if (extras.style) {
+        newExtras.style.push(newStyle)
+      } else {
+        newExtras.style = [newStyle]
+      }
+    } else {
+      newExtras = {
+        style: [newStyle]
+      }
+    }
+    return newExtras
+  },
+
+  logDebug: function logDebug (nodeTree, level = 0) {
+    for (let i = 0; i < nodeTree.length; i++) {
+      const node = nodeTree[i]
+
+      if (node) {
+        const prefix = Array(level).join('-')
+        console.log(
+          prefix + '> ' + node.key + ', NODE TYPE: ' + node.type.displayName
+        )
+        if (Array.isArray(node.props.children)) {
+          this.logDebug(node.props.children, level + 1)
+        }
+      }
+    }
+  }
 }
 
-module.exports = Utils;
+module.exports = Utils

--- a/entry.js
+++ b/entry.js
@@ -1,2 +1,0 @@
-module.exports = require('./lib/index.js');
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,38 +1,42 @@
-import React from "react";
-import { StyleProp, TextStyle, ViewProps, ViewStyle } from "react-native";
+import React from 'react'
+import { StyleProp, TextStyle, ViewProps, ViewStyle } from 'react-native'
 
 export interface IProps {
-    debug?: boolean;
-    parseInline?: boolean;
-    useDefaultStyles?: boolean;
-    renderImage?: (src: string, alt: string, title: string) => React.ReactNode;
-    renderLink?: (href: string, title: string, children: React.ReactNode) => React.ReactNode;
-    renderListBullet?: (ordered: boolean, index: number) => React.ReactNode;
-    markdownStyles?: {
-        block?: StyleProp<ViewStyle>;
-        blockQuote?: StyleProp<TextStyle>;
-        del?: StyleProp<TextStyle>;
-        em?: StyleProp<TextStyle>;
-        h1?: StyleProp<TextStyle>;
-        h2?: StyleProp<TextStyle>;
-        h3?: StyleProp<TextStyle>;
-        h4?: StyleProp<TextStyle>;
-        h5?: StyleProp<TextStyle>;
-        h6?: StyleProp<TextStyle>;
-        hr?: StyleProp<TextStyle>;
-        image?: StyleProp<TextStyle>;
-        imageWrapper?: StyleProp<ViewStyle>;
-        link?: StyleProp<TextStyle>;
-        linkWrapper?: StyleProp<TextStyle>;
-        list?: StyleProp<TextStyle>;
-        listItem?: StyleProp<TextStyle>;
-        listItemBullet?: StyleProp<TextStyle>;
-        listItemContent?: StyleProp<TextStyle>;
-        listItemNumber?: StyleProp<TextStyle>;
-        strong?: StyleProp<TextStyle>;
-        text?: StyleProp<TextStyle>;
-        u?: StyleProp<TextStyle>;
-    };
+  debug?: boolean
+  parseInline?: boolean
+  useDefaultStyles?: boolean
+  renderImage?: (src: string, alt: string, title: string) => React.ReactNode
+  renderLink?: (
+    href: string,
+    title: string,
+    children: React.ReactNode
+  ) => React.ReactNode
+  renderListBullet?: (ordered: boolean, index: number) => React.ReactNode
+  markdownStyles?: {
+    block?: StyleProp<ViewStyle>
+    blockQuote?: StyleProp<TextStyle>
+    del?: StyleProp<TextStyle>
+    em?: StyleProp<TextStyle>
+    h1?: StyleProp<TextStyle>
+    h2?: StyleProp<TextStyle>
+    h3?: StyleProp<TextStyle>
+    h4?: StyleProp<TextStyle>
+    h5?: StyleProp<TextStyle>
+    h6?: StyleProp<TextStyle>
+    hr?: StyleProp<TextStyle>
+    image?: StyleProp<TextStyle>
+    imageWrapper?: StyleProp<ViewStyle>
+    link?: StyleProp<TextStyle>
+    linkWrapper?: StyleProp<TextStyle>
+    list?: StyleProp<TextStyle>
+    listItem?: StyleProp<TextStyle>
+    listItemBullet?: StyleProp<TextStyle>
+    listItemContent?: StyleProp<TextStyle>
+    listItemNumber?: StyleProp<TextStyle>
+    strong?: StyleProp<TextStyle>
+    text?: StyleProp<TextStyle>
+    u?: StyleProp<TextStyle>
+  }
 }
 
 export default class Markdown extends React.Component<IProps & ViewProps> {}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import {
   TouchableOpacity,
@@ -9,77 +9,51 @@ import {
   StyleSheet
 } from 'react-native'
 import SimpleMarkdown from 'simple-markdown'
+import { useMemoOne } from 'use-memo-one'
 
-import styles from './styles'
+import defaultStyles from './styles'
 import Utils from './Utils'
 
-class Markdown extends Component {
-  constructor (props) {
-    super(props)
-
-    const rules = SimpleMarkdown.defaultRules
-    this.parser = SimpleMarkdown.parserFor(rules)
-    this.reactOutput = SimpleMarkdown.reactFor(
-      SimpleMarkdown.ruleOutput(rules, 'react')
-    )
-    const blockSource = this.props.children + '\n\n'
-    const parseTree = this.parser(blockSource, {
-      inline: this.props.parseInline
+const Markdown = ({
+  children,
+  debug,
+  parseInline,
+  markdownStyles,
+  useDefaultStyles = true,
+  renderLink: customRenderLink,
+  renderImage: customRenderImage,
+  renderListBullet: customRenderListBullet,
+  ...otherProps
+}) => {
+  const parser = useMemoOne(
+    () => SimpleMarkdown.parserFor(SimpleMarkdown.defaultRules),
+    []
+  )
+  const reactOutput = useMemoOne(
+    () =>
+      SimpleMarkdown.reactFor(
+        SimpleMarkdown.ruleOutput(SimpleMarkdown.defaultRules, 'react')
+      ),
+    []
+  )
+  const syntaxTree = React.useMemo(() => {
+    const parseTree = parser(children + '\n\n', {
+      inline: parseInline
     })
-    const outputResult = this.reactOutput(parseTree)
+    return reactOutput(parseTree)
+  }, [parser, reactOutput, children])
 
-    const defaultStyles = this.props.useDefaultStyles && styles ? styles : {}
-    const _styles = StyleSheet.create(
-      Object.assign({}, defaultStyles, this.props.markdownStyles)
-    )
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create(
+        Object.assign({}, useDefaultStyles ? defaultStyles : {}, markdownStyles)
+      ),
+    [useDefaultStyles, markdownStyles]
+  )
 
-    this.state = {
-      syntaxTree: outputResult,
-      styles: _styles
-    }
-  }
-
-  componentWillReceiveProps (nextProps) {
-    const newState = {}
-
-    if (nextProps.children !== this.props.children) {
-      const blockSource = nextProps.children + '\n\n'
-      const parseTree = this.parser(blockSource, {
-        inline: this.props.parseInline
-      })
-      const outputResult = this.reactOutput(parseTree)
-
-      newState.syntaxTree = outputResult
-    }
-
-    if (nextProps.markdownStyles !== this.props.markdownStyles) {
-      const defaultStyles = this.props.useDefaultStyles && styles ? styles : {}
-      newState.styles = StyleSheet.create(
-        Object.assign(defaultStyles, nextProps.markdownStyles)
-      )
-    }
-
-    if (Object.keys(newState).length !== 0) {
-      this.setState(newState)
-    }
-  }
-
-  shouldComponentUpdate (nextProps) {
-    return (
-      this.props.children !== nextProps.children ||
-      this.props.markdownStyles !== nextProps.markdownStyles
-    )
-  }
-
-  renderImage (node, key) {
-    const { styles } = this.state
-
-    if (this.props.renderImage) {
-      return this.props.renderImage(
-        node.props.src,
-        node.props.alt,
-        node.props.title
-      )
+  function renderImage (node, key) {
+    if (customRenderImage) {
+      return customRenderImage(node.props.src, node.props.alt, node.props.title)
     }
 
     return (
@@ -89,25 +63,19 @@ class Markdown extends Component {
     )
   }
 
-  renderLine (node, key) {
-    const { styles } = this.state
-
+  function renderLine (node, key) {
     return <View style={styles.hr} key={'hr_' + key} />
   }
 
-  renderList (node, key, ordered) {
-    const { styles } = this.state
-
+  function renderList (node, key, ordered) {
     return (
       <View key={'list_' + key} style={styles.list}>
-        {this.renderNodes(node.props.children, key, { ordered })}
+        {renderNodes(node.props.children, key, { ordered })}
       </View>
     )
   }
 
-  renderListBullet (ordered, index) {
-    const { styles } = this.state
-
+  function renderListBullet (ordered, index) {
     if (ordered) {
       return (
         <Text key={'listBullet_' + index} style={styles.listItemNumber}>
@@ -119,38 +87,14 @@ class Markdown extends Component {
     return <View key={'listBullet_' + index} style={styles.listItemBullet} />
   }
 
-  renderListItem (node, key, index, extras) {
-    const { styles } = this.state
-
-    const children = this.renderNodes(node.props.children, key, extras)
-
-    const SafeWrapper = Utils.isTextOnly(children) ? Text : View
-
-    return (
-      <View style={styles.listItem} key={'listItem_' + key}>
-        {this.props.renderListBullet
-          ? this.props.renderListBullet(extras.ordered, index)
-          : this.renderListBullet(extras.ordered, index)}
-        <SafeWrapper
-          key={'listItemContent_' + key}
-          style={styles.listItemContent}
-        >
-          {children}
-        </SafeWrapper>
-      </View>
-    )
-  }
-
-  renderText (node, key, extras) {
-    const { styles } = this.state
-
+  function renderText (node, key, extras) {
     const style =
       extras && extras.style ? [styles.text].concat(extras.style) : styles.text
 
     if (node.props) {
       return (
         <Text key={key} style={style}>
-          {this.renderNodes(node.props.children, key, extras)}
+          {renderNodes(node.props.children, key, extras)}
         </Text>
       )
     } else {
@@ -162,13 +106,32 @@ class Markdown extends Component {
     }
   }
 
-  renderLink (node, key) {
-    const { styles } = this.state
-    const extras = Utils.concatStyles(null, styles.link)
-    const children = this.renderNodes(node.props.children, key, extras)
+  function renderListItem (node, key, index, extras) {
+    const children = renderNodes(node.props.children, key, extras)
 
-    if (this.props.renderLink) {
-      return this.props.renderLink(node.props.href, node.props.title, children)
+    const SafeWrapper = Utils.isTextOnly(children) ? Text : View
+
+    return (
+      <View style={styles.listItem} key={'listItem_' + key}>
+        {customRenderListBullet
+          ? customRenderListBullet(extras.ordered, index)
+          : renderListBullet(extras.ordered, index)}
+        <SafeWrapper
+          key={'listItemContent_' + key}
+          style={styles.listItemContent}
+        >
+          {children}
+        </SafeWrapper>
+      </View>
+    )
+  }
+
+  function renderLink (node, key) {
+    const extras = Utils.concatStyles(null, styles.link)
+    const children = renderNodes(node.props.children, key, extras)
+
+    if (customRenderLink) {
+      return customRenderLink(node.props.href, node.props.title, children)
     }
 
     const SafeWrapper = Utils.isTextOnly(children) ? Text : TouchableOpacity
@@ -184,16 +147,14 @@ class Markdown extends Component {
     )
   }
 
-  renderBlockQuote (node, key, extras) {
+  function renderBlockQuote (node, key, extras) {
     extras = extras
       ? Object.assign(extras, { blockQuote: true })
       : { blockQuote: true }
-    return this.renderBlock(node, key, extras)
+    return renderBlock(node, key, extras)
   }
 
-  renderBlock (node, key, extras) {
-    const { styles } = this.state
-
+  function renderBlock (node, key, extras) {
     const style = [styles.block]
     let isBlockQuote
     if (extras && extras.blockQuote) {
@@ -204,7 +165,7 @@ class Markdown extends Component {
        */
       delete extras.blockQuote
     }
-    const nodes = this.renderNodes(node.props.children, key, extras)
+    const nodes = renderNodes(node.props.children, key, extras)
 
     if (isBlockQuote) {
       style.push(styles.blockQuote)
@@ -231,7 +192,7 @@ class Markdown extends Component {
     }
   }
 
-  renderNode (node, key, index, extras) {
+  function renderNode (node, key, index, extras) {
     if (
       node == null ||
       node === 'null' ||
@@ -241,83 +202,72 @@ class Markdown extends Component {
       return null
     }
 
-    const { styles } = this.state
-
     switch (node.type) {
       case 'h1':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.h1))
+        return renderText(node, key, Utils.concatStyles(extras, styles.h1))
       case 'h2':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.h2))
+        return renderText(node, key, Utils.concatStyles(extras, styles.h2))
       case 'h3':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.h3))
+        return renderText(node, key, Utils.concatStyles(extras, styles.h3))
       case 'h4':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.h4))
+        return renderText(node, key, Utils.concatStyles(extras, styles.h4))
       case 'h5':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.h5))
+        return renderText(node, key, Utils.concatStyles(extras, styles.h5))
       case 'h6':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.h6))
+        return renderText(node, key, Utils.concatStyles(extras, styles.h6))
       case 'hr':
-        return this.renderLine(node, key)
+        return renderLine(node, key)
       case 'div':
-        return this.renderBlock(node, key, extras)
+        return renderBlock(node, key, extras)
       case 'ul':
-        return this.renderList(node, key, false)
+        return renderList(node, key, false)
       case 'ol':
-        return this.renderList(node, key, true)
+        return renderList(node, key, true)
       case 'li':
-        return this.renderListItem(node, key, index, extras)
+        return renderListItem(node, key, index, extras)
       case 'a':
-        return this.renderLink(node, key)
+        return renderLink(node, key)
       case 'img':
-        return this.renderImage(node, key)
+        return renderImage(node, key)
       case 'strong':
-        return this.renderText(
-          node,
-          key,
-          Utils.concatStyles(extras, styles.strong)
-        )
+        return renderText(node, key, Utils.concatStyles(extras, styles.strong))
       case 'del':
-        return this.renderText(
-          node,
-          key,
-          Utils.concatStyles(extras, styles.del)
-        )
+        return renderText(node, key, Utils.concatStyles(extras, styles.del))
       case 'em':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.em))
+        return renderText(node, key, Utils.concatStyles(extras, styles.em))
       case 'u':
-        return this.renderText(node, key, Utils.concatStyles(extras, styles.u))
+        return renderText(node, key, Utils.concatStyles(extras, styles.u))
       case 'blockquote':
-        return this.renderBlockQuote(node, key)
+        return renderBlockQuote(node, key)
       case undefined:
-        return this.renderText(node, key, extras)
+        return renderText(node, key, extras)
       default:
-        if (this.props.debug) {
+        if (debug) {
           console.log('Node type ' + node.type + ' is not supported')
         }
         return null
     }
   }
 
-  renderNodes (nodes, key, extras) {
+  function renderNodes (nodes, key, extras) {
     return nodes.map((node, index) => {
       const newKey = key ? key + '_' + index : index + ''
-      return this.renderNode(node, newKey, index, extras)
+      return renderNode(node, newKey, index, extras)
     })
   }
 
-  render () {
-    const content = this.renderNodes(this.state.syntaxTree, null, null)
+  const content = renderNodes(syntaxTree, null, null)
 
-    if (this.props.debug) {
-      console.log('\n\n==== LOGGING NODE TREE ===')
-      Utils.logDebug(content)
-    }
-
-    return <View {...this.props}>{content}</View>
+  if (debug) {
+    console.log('\n\n==== LOGGING NODE TREE ===')
+    Utils.logDebug(content)
   }
+
+  return <View {...otherProps}>{content}</View>
 }
 
 Markdown.propTypes = {
+  children: PropTypes.string.isRequired,
   debug: PropTypes.bool,
   parseInline: PropTypes.bool,
   markdownStyles: PropTypes.object,
@@ -325,13 +275,6 @@ Markdown.propTypes = {
   renderImage: PropTypes.func,
   renderLink: PropTypes.func,
   renderListBullet: PropTypes.func
-}
-
-Markdown.defaultProps = {
-  debug: false,
-  useDefaultStyles: true,
-  parseInline: false,
-  markdownStyles: {}
 }
 
 export default Markdown

--- a/index.js
+++ b/index.js
@@ -1,280 +1,337 @@
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import {
-    TouchableOpacity,
-    Text,
-    View,
-    Image,
-    Linking,
-    StyleSheet
-} from 'react-native';
-import SimpleMarkdown from 'simple-markdown';
+  TouchableOpacity,
+  Text,
+  View,
+  Image,
+  Linking,
+  StyleSheet
+} from 'react-native'
+import SimpleMarkdown from 'simple-markdown'
 
-import styles from './styles';
-import Utils from './Utils';
+import styles from './styles'
+import Utils from './Utils'
 
 class Markdown extends Component {
-    constructor(props) {
-        super(props);
+  constructor (props) {
+    super(props)
 
-        const rules = SimpleMarkdown.defaultRules;
-        this.parser = SimpleMarkdown.parserFor(rules);
-        this.reactOutput = SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, 'react'));
-        const blockSource = this.props.children + '\n\n';
-        const parseTree = this.parser(blockSource, { inline: this.props.parseInline });
-        const outputResult = this.reactOutput(parseTree);
+    const rules = SimpleMarkdown.defaultRules
+    this.parser = SimpleMarkdown.parserFor(rules)
+    this.reactOutput = SimpleMarkdown.reactFor(
+      SimpleMarkdown.ruleOutput(rules, 'react')
+    )
+    const blockSource = this.props.children + '\n\n'
+    const parseTree = this.parser(blockSource, {
+      inline: this.props.parseInline
+    })
+    const outputResult = this.reactOutput(parseTree)
 
-        const defaultStyles = this.props.useDefaultStyles && styles ? styles : {};
-        const _styles = StyleSheet.create(Object.assign({}, defaultStyles, this.props.markdownStyles));
+    const defaultStyles = this.props.useDefaultStyles && styles ? styles : {}
+    const _styles = StyleSheet.create(
+      Object.assign({}, defaultStyles, this.props.markdownStyles)
+    )
 
-        this.state = {
-            syntaxTree: outputResult,
-            styles: _styles
-        };
+    this.state = {
+      syntaxTree: outputResult,
+      styles: _styles
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    const newState = {}
+
+    if (nextProps.children !== this.props.children) {
+      const blockSource = nextProps.children + '\n\n'
+      const parseTree = this.parser(blockSource, {
+        inline: this.props.parseInline
+      })
+      const outputResult = this.reactOutput(parseTree)
+
+      newState.syntaxTree = outputResult
     }
 
-    componentWillReceiveProps(nextProps) {
-
-        let newState = {};
-
-        if (nextProps.children !== this.props.children) {
-            const blockSource = nextProps.children + '\n\n';
-            const parseTree = this.parser(blockSource, { inline: this.props.parseInline });
-            const outputResult = this.reactOutput(parseTree);
-
-            newState.syntaxTree = outputResult;
-        }
-
-        if (nextProps.markdownStyles !== this.props.markdownStyles) {
-            const defaultStyles = this.props.useDefaultStyles && styles ? styles : {};
-            newState.styles = StyleSheet.create(Object.assign(defaultStyles, nextProps.markdownStyles));
-        }
-
-        if (Object.keys(newState).length !== 0) {
-            this.setState(newState);
-        }
+    if (nextProps.markdownStyles !== this.props.markdownStyles) {
+      const defaultStyles = this.props.useDefaultStyles && styles ? styles : {}
+      newState.styles = StyleSheet.create(
+        Object.assign(defaultStyles, nextProps.markdownStyles)
+      )
     }
 
-    shouldComponentUpdate(nextProps) {
-        return this.props.children !== nextProps.children || this.props.markdownStyles !== nextProps.markdownStyles;
+    if (Object.keys(newState).length !== 0) {
+      this.setState(newState)
+    }
+  }
+
+  shouldComponentUpdate (nextProps) {
+    return (
+      this.props.children !== nextProps.children ||
+      this.props.markdownStyles !== nextProps.markdownStyles
+    )
+  }
+
+  renderImage (node, key) {
+    const { styles } = this.state
+
+    if (this.props.renderImage) {
+      return this.props.renderImage(
+        node.props.src,
+        node.props.alt,
+        node.props.title
+      )
     }
 
-    renderImage(node, key) {
-        const { styles } = this.state;
+    return (
+      <View style={styles.imageWrapper} key={'imageWrapper_' + key}>
+        <Image source={{ uri: node.props.src }} style={styles.image} />
+      </View>
+    )
+  }
 
-        if (this.props.renderImage) {
-            return this.props.renderImage(node.props.src, node.props.alt, node.props.title);
-        }
+  renderLine (node, key) {
+    const { styles } = this.state
 
-        return (
-            <View style={styles.imageWrapper} key={'imageWrapper_' + key}>
-                <Image source={{ uri: node.props.src }} style={styles.image} />
-            </View>
-        );
+    return <View style={styles.hr} key={'hr_' + key} />
+  }
+
+  renderList (node, key, ordered) {
+    const { styles } = this.state
+
+    return (
+      <View key={'list_' + key} style={styles.list}>
+        {this.renderNodes(node.props.children, key, { ordered })}
+      </View>
+    )
+  }
+
+  renderListBullet (ordered, index) {
+    const { styles } = this.state
+
+    if (ordered) {
+      return (
+        <Text key={'listBullet_' + index} style={styles.listItemNumber}>
+          {index + 1 + '.'}
+        </Text>
+      )
     }
 
-    renderLine(node, key) {
-        const { styles } = this.state;
+    return <View key={'listBullet_' + index} style={styles.listItemBullet} />
+  }
 
-        return (
-            <View style={styles.hr} key={'hr_' + key} />
-        );
+  renderListItem (node, key, index, extras) {
+    const { styles } = this.state
+
+    const children = this.renderNodes(node.props.children, key, extras)
+
+    const SafeWrapper = Utils.isTextOnly(children) ? Text : View
+
+    return (
+      <View style={styles.listItem} key={'listItem_' + key}>
+        {this.props.renderListBullet
+          ? this.props.renderListBullet(extras.ordered, index)
+          : this.renderListBullet(extras.ordered, index)}
+        <SafeWrapper
+          key={'listItemContent_' + key}
+          style={styles.listItemContent}
+        >
+          {children}
+        </SafeWrapper>
+      </View>
+    )
+  }
+
+  renderText (node, key, extras) {
+    const { styles } = this.state
+
+    const style =
+      extras && extras.style ? [styles.text].concat(extras.style) : styles.text
+
+    if (node.props) {
+      return (
+        <Text key={key} style={style}>
+          {this.renderNodes(node.props.children, key, extras)}
+        </Text>
+      )
+    } else {
+      return (
+        <Text key={key} style={style}>
+          {node}
+        </Text>
+      )
+    }
+  }
+
+  renderLink (node, key) {
+    const { styles } = this.state
+    const extras = Utils.concatStyles(null, styles.link)
+    const children = this.renderNodes(node.props.children, key, extras)
+
+    if (this.props.renderLink) {
+      return this.props.renderLink(node.props.href, node.props.title, children)
     }
 
-    renderList(node, key, ordered) {
+    const SafeWrapper = Utils.isTextOnly(children) ? Text : TouchableOpacity
 
-        const { styles } = this.state;
+    return (
+      <SafeWrapper
+        style={styles.linkWrapper}
+        key={'linkWrapper_' + key}
+        onPress={() => Linking.openURL(node.props.href).catch(() => {})}
+      >
+        {children}
+      </SafeWrapper>
+    )
+  }
 
-        return (
-            <View key={'list_' + key} style={styles.list}>
-                {this.renderNodes(node.props.children, key, { ordered })}
-            </View>
-        );
+  renderBlockQuote (node, key, extras) {
+    extras = extras
+      ? Object.assign(extras, { blockQuote: true })
+      : { blockQuote: true }
+    return this.renderBlock(node, key, extras)
+  }
+
+  renderBlock (node, key, extras) {
+    const { styles } = this.state
+
+    const style = [styles.block]
+    let isBlockQuote
+    if (extras && extras.blockQuote) {
+      isBlockQuote = true
+
+      /* Ensure that blockQuote style is applied only once, and not for
+       * all nested components as well (unless there is a nested blockQuote)
+       */
+      delete extras.blockQuote
+    }
+    const nodes = this.renderNodes(node.props.children, key, extras)
+
+    if (isBlockQuote) {
+      style.push(styles.blockQuote)
+      return (
+        <View
+          key={'blockQuote_' + key}
+          style={[styles.block, styles.blockQuote]}
+        >
+          <Text>{nodes}</Text>
+        </View>
+      )
+    } else if (Utils.isTextOnly(nodes)) {
+      return (
+        <Text key={'block_text_' + key} style={styles.block}>
+          {nodes}
+        </Text>
+      )
+    } else {
+      return (
+        <View key={'block_' + key} style={styles.block}>
+          {nodes}
+        </View>
+      )
+    }
+  }
+
+  renderNode (node, key, index, extras) {
+    if (
+      node == null ||
+      node === 'null' ||
+      node === 'undefined' ||
+      node === ''
+    ) {
+      return null
     }
 
-    renderListBullet(ordered, index) {
+    const { styles } = this.state
 
-        const { styles } = this.state;
-
-        if (ordered) {
-            return (
-                <Text key={'listBullet_' + index} style={styles.listItemNumber}>{index + 1 + '.'}</Text>
-            );
-        }
-
-        return (
-            <View key={'listBullet_' + index} style={styles.listItemBullet} />
-        );
-    }
-
-    renderListItem(node, key, index, extras) {
-
-        const { styles } = this.state;
-
-        let children = this.renderNodes(node.props.children, key, extras);
-
-        const SafeWrapper = Utils.isTextOnly(children) ? Text : View;
-
-        return (
-            <View style={styles.listItem} key={'listItem_' + key}>
-                {this.props.renderListBullet ? this.props.renderListBullet(extras.ordered, index) : this.renderListBullet(extras.ordered, index)}
-                <SafeWrapper key={'listItemContent_' + key} style={styles.listItemContent}>
-                    {children}
-                </SafeWrapper>
-            </View>
-        );
-    }
-
-    renderText(node, key, extras) {
-
-        const { styles } = this.state;
-
-        let style = (extras && extras.style) ? [styles.text].concat(extras.style) : styles.text;
-
-        if (node.props) {
-            return (
-                <Text key={key} style={style}>
-                    {this.renderNodes(node.props.children, key, extras)}
-                </Text>
-            );
-        } else {
-            return (
-                <Text key={key} style={style}>{node}</Text>
-            );
-        }
-    }
-
-    renderLink(node, key) {
-
-        const { styles } = this.state;
-        let extras = Utils.concatStyles(null, styles.link);
-        let children = this.renderNodes(node.props.children, key, extras);
-
-        if (this.props.renderLink) {
-            return this.props.renderLink(node.props.href, node.props.title, children);
-        }
-
-        const SafeWrapper = Utils.isTextOnly(children) ? Text : TouchableOpacity;
-
-        return (
-            <SafeWrapper style={styles.linkWrapper} key={'linkWrapper_' + key} onPress={() => Linking.openURL(node.props.href).catch(() => { })}>
-                {children}
-            </SafeWrapper>
-        );
-    }
-
-    renderBlockQuote(node, key, extras) {
-        extras = extras ? Object.assign(extras, { blockQuote: true }) : { blockQuote: true };
-        return this.renderBlock(node, key, extras);
-    }
-
-    renderBlock(node, key, extras) {
-        const { styles } = this.state;
-
-        let style = [styles.block];
-        let isBlockQuote;
-        if (extras && extras.blockQuote) {
-            isBlockQuote = true;
-
-            /* Ensure that blockQuote style is applied only once, and not for
-             * all nested components as well (unless there is a nested blockQuote)
-             */
-            delete extras.blockQuote;
-        }
-        const nodes = this.renderNodes(node.props.children, key, extras);
-
-        if (isBlockQuote) {
-            style.push(styles.blockQuote)
-            return (
-                <View key={'blockQuote_' + key} style={[styles.block, styles.blockQuote]}>
-                    <Text>{nodes}</Text>
-                </View>
-            );
-        }
-        else if (Utils.isTextOnly(nodes)) {
-            return (
-                <Text key={`block_text_` + key} style={styles.block}>{nodes}</Text>
-            );
-        }
-        else {
-            return (
-                <View key={'block_' + key} style={styles.block}>
-                    {nodes}
-                </View>
-            );
-        }
-    }
-
-    renderNode(node, key, index, extras) {
-        if (node == null || node == "null" || node == "undefined" || node == "") {
-            return null;
-        }
-
-        const { styles } = this.state;
-
-
-        switch (node.type) {
-            case 'h1': return this.renderText(node, key, Utils.concatStyles(extras, styles.h1));
-            case 'h2': return this.renderText(node, key, Utils.concatStyles(extras, styles.h2));
-            case 'h3': return this.renderText(node, key, Utils.concatStyles(extras, styles.h3));
-            case 'h4': return this.renderText(node, key, Utils.concatStyles(extras, styles.h4))
-            case 'h5': return this.renderText(node, key, Utils.concatStyles(extras, styles.h5));
-            case 'h6': return this.renderText(node, key, Utils.concatStyles(extras, styles.h6));
-            case 'hr': return this.renderLine(node, key);
-            case 'div': return this.renderBlock(node, key, extras);
-            case 'ul': return this.renderList(node, key, false);
-            case 'ol': return this.renderList(node, key, true);
-            case 'li': return this.renderListItem(node, key, index, extras);
-            case 'a': return this.renderLink(node, key);
-            case 'img': return this.renderImage(node, key);
-            case 'strong': return this.renderText(node, key, Utils.concatStyles(extras, styles.strong));
-            case 'del': return this.renderText(node, key, Utils.concatStyles(extras, styles.del));
-            case 'em': return this.renderText(node, key, Utils.concatStyles(extras, styles.em));
-            case 'u': return this.renderText(node, key, Utils.concatStyles(extras, styles.u));
-            case 'blockquote': return this.renderBlockQuote(node, key);
-            case undefined: return this.renderText(node, key, extras);
-            default: if (this.props.debug) console.log('Node type ' + node.type + ' is not supported'); return null;
-        }
-    }
-
-    renderNodes(nodes, key, extras) {
-        return nodes.map((node, index) => {
-            const newKey = key ? key + '_' + index : index + '';
-            return this.renderNode(node, newKey, index, extras);
-        });
-    }
-
-    render() {
-        let content = this.renderNodes(this.state.syntaxTree, null, null);
-
+    switch (node.type) {
+      case 'h1':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.h1))
+      case 'h2':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.h2))
+      case 'h3':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.h3))
+      case 'h4':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.h4))
+      case 'h5':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.h5))
+      case 'h6':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.h6))
+      case 'hr':
+        return this.renderLine(node, key)
+      case 'div':
+        return this.renderBlock(node, key, extras)
+      case 'ul':
+        return this.renderList(node, key, false)
+      case 'ol':
+        return this.renderList(node, key, true)
+      case 'li':
+        return this.renderListItem(node, key, index, extras)
+      case 'a':
+        return this.renderLink(node, key)
+      case 'img':
+        return this.renderImage(node, key)
+      case 'strong':
+        return this.renderText(
+          node,
+          key,
+          Utils.concatStyles(extras, styles.strong)
+        )
+      case 'del':
+        return this.renderText(
+          node,
+          key,
+          Utils.concatStyles(extras, styles.del)
+        )
+      case 'em':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.em))
+      case 'u':
+        return this.renderText(node, key, Utils.concatStyles(extras, styles.u))
+      case 'blockquote':
+        return this.renderBlockQuote(node, key)
+      case undefined:
+        return this.renderText(node, key, extras)
+      default:
         if (this.props.debug) {
-            console.log('\n\n==== LOGGING NODE TREE ===');
-            Utils.logDebug(content);
+          console.log('Node type ' + node.type + ' is not supported')
         }
-
-        return (
-            <View {...this.props}>
-                {content}
-            </View>
-        );
+        return null
     }
+  }
+
+  renderNodes (nodes, key, extras) {
+    return nodes.map((node, index) => {
+      const newKey = key ? key + '_' + index : index + ''
+      return this.renderNode(node, newKey, index, extras)
+    })
+  }
+
+  render () {
+    const content = this.renderNodes(this.state.syntaxTree, null, null)
+
+    if (this.props.debug) {
+      console.log('\n\n==== LOGGING NODE TREE ===')
+      Utils.logDebug(content)
+    }
+
+    return <View {...this.props}>{content}</View>
+  }
 }
 
 Markdown.propTypes = {
-    debug: PropTypes.bool,
-    parseInline: PropTypes.bool,
-    markdownStyles: PropTypes.object,
-    useDefaultStyles: PropTypes.bool,
-    renderImage: PropTypes.func,
-    renderLink: PropTypes.func,
-    renderListBullet: PropTypes.func,
-};
+  debug: PropTypes.bool,
+  parseInline: PropTypes.bool,
+  markdownStyles: PropTypes.object,
+  useDefaultStyles: PropTypes.bool,
+  renderImage: PropTypes.func,
+  renderLink: PropTypes.func,
+  renderListBullet: PropTypes.func
+}
 
 Markdown.defaultProps = {
-    debug: false,
-    useDefaultStyles: true,
-    parseInline: false,
-    markdownStyles: {}
-};
+  debug: false,
+  useDefaultStyles: true,
+  parseInline: false,
+  markdownStyles: {}
+}
 
-export default Markdown;
+export default Markdown

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+    "name": "react-native-easy-markdown",
+    "version": "1.5.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/prop-types": {
+            "version": "15.7.3",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+        },
+        "@types/react": {
+            "version": "16.9.22",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.22.tgz",
+            "integrity": "sha512-7OSt4EGiLvy0h5R7X+r0c7S739TCU/LvWbkNOrm10lUwNHe7XPz5OLhLOSZeCkqO9JSCly1NkYJ7ODTUqVnHJQ==",
+            "requires": {
+                "@types/prop-types": "*",
+                "csstype": "^2.2.0"
+            }
+        },
+        "csstype": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+            "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
+        },
+        "simple-markdown": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/simple-markdown/-/simple-markdown-0.7.2.tgz",
+            "integrity": "sha512-XfCvqqzMyzRj4L7eIxJgGaQ2Gaxr20GhTFMB+1yuY8q3xffjzmOg4Q5tC0kcaJPV42NNUHCQDaRK6jzi3/RhrA==",
+            "requires": {
+                "@types/react": ">=16.0.0"
+            }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1813,6 +1813,11 @@
                 "punycode": "^2.1.0"
             }
         },
+        "use-memo-one": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
+            "integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ=="
+        },
         "v8-compile-cache": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.8.3"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+            "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
         "@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -18,10 +38,1525 @@
                 "csstype": "^2.2.0"
             }
         },
+        "acorn": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+            "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+            "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+            "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-escapes": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "array-includes": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+            "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0",
+                "is-string": "^1.0.5"
+            }
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "contains-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
         "csstype": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
             "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
+        },
+        "debug": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dev": true,
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "debug-log": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+            "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "deglob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+            "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+            "dev": true,
+            "requires": {
+                "find-root": "^1.0.0",
+                "glob": "^7.0.5",
+                "ignore": "^5.0.0",
+                "pkg-config": "^1.1.0",
+                "run-parallel": "^1.1.2",
+                "uniq": "^1.0.1"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "5.1.4",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+                    "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+                    "dev": true
+                }
+            }
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.17.4",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+            "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.1.5",
+                "is-regex": "^1.0.5",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimleft": "^2.1.1",
+                "string.prototype.trimright": "^2.1.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
+            "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.10.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^1.4.2",
+                "eslint-visitor-keys": "^1.1.0",
+                "espree": "^6.1.1",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^5.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^5.0.0",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.4.1",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.14",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.1",
+                "semver": "^6.1.2",
+                "strip-ansi": "^5.2.0",
+                "strip-json-comments": "^3.0.1",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
+            }
+        },
+        "eslint-config-standard": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+            "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+            "dev": true
+        },
+        "eslint-config-standard-jsx": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+            "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
+            "dev": true
+        },
+        "eslint-import-resolver-node": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+            "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+            "dev": true,
+            "requires": {
+                "debug": "^2.6.9",
+                "resolve": "^1.13.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-module-utils": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+            "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+            "dev": true,
+            "requires": {
+                "debug": "^2.6.9",
+                "pkg-dir": "^2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-es": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+            "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+            "dev": true,
+            "requires": {
+                "eslint-utils": "^1.4.2",
+                "regexpp": "^3.0.0"
+            },
+            "dependencies": {
+                "regexpp": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+                    "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-import": {
+            "version": "2.18.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+            "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+            "dev": true,
+            "requires": {
+                "array-includes": "^3.0.3",
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.9",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "^0.3.2",
+                "eslint-module-utils": "^2.4.0",
+                "has": "^1.0.3",
+                "minimatch": "^3.0.4",
+                "object.values": "^1.1.0",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.11.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "isarray": "^1.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-node": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+            "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
+            "dev": true,
+            "requires": {
+                "eslint-plugin-es": "^2.0.0",
+                "eslint-utils": "^1.4.2",
+                "ignore": "^5.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.10.1",
+                "semver": "^6.1.0"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "5.1.4",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+                    "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-promise": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+            "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+            "dev": true
+        },
+        "eslint-plugin-react": {
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+            "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+            "dev": true,
+            "requires": {
+                "array-includes": "^3.0.3",
+                "doctrine": "^2.1.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.1.0",
+                "object.entries": "^1.1.0",
+                "object.fromentries": "^2.0.0",
+                "object.values": "^1.1.0",
+                "prop-types": "^15.7.2",
+                "resolve": "^1.10.1"
+            },
+            "dependencies": {
+                "doctrine": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-standard": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+            "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+            "dev": true
+        },
+        "eslint-scope": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+            "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-utils": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+            "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+            "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+            "dev": true
+        },
+        "espree": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+            "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.1.0",
+                "acorn-jsx": "^5.1.0",
+                "eslint-visitor-keys": "^1.1.0"
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+            "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.0.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.1.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
+        },
+        "external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            }
+        },
+        "fast-deep-equal": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+            "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^2.0.1"
+            }
+        },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "dev": true
+        },
+        "find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
+            "requires": {
+                "locate-path": "^2.0.0"
+            }
+        },
+        "flat-cache": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+            "dev": true,
+            "requires": {
+                "flatted": "^2.0.0",
+                "rimraf": "2.6.3",
+                "write": "1.0.3"
+            }
+        },
+        "flatted": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+            "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+            "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+            "dev": true
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+            "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+            "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+            "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.12",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.4.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.1.0",
+                "through": "^2.3.6"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-callable": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+            "dev": true
+        },
+        "is-date-object": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-string": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "jsx-ast-utils": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+            "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+            "dev": true,
+            "requires": {
+                "array-includes": "^3.0.3",
+                "object.assign": "^4.1.0"
+            }
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "load-json-file": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-inspect": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+            "dev": true
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "object.entries": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+            "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
+            }
+        },
+        "object.fromentries": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+            "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
+            }
+        },
+        "object.values": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+            "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
+            "requires": {
+                "p-try": "^1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "requires": {
+                "p-limit": "^1.1.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.2.0"
+            }
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true,
+            "requires": {
+                "pify": "^2.0.0"
+            }
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pkg-conf": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+            "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "load-json-file": "^5.2.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+                    "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.15",
+                        "parse-json": "^4.0.0",
+                        "pify": "^4.0.1",
+                        "strip-bom": "^3.0.0",
+                        "type-fest": "^0.3.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+                    "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
+            }
+        },
+        "pkg-config": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+            "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+            "dev": true,
+            "requires": {
+                "debug-log": "^1.0.0",
+                "find-root": "^1.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
+        "pkg-dir": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.1.0"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
+        "prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "react-is": {
+            "version": "16.12.0",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+            "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+            }
+        },
+        "regexpp": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+            "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
+        },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+            "dev": true
+        },
+        "rxjs": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+            "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
         },
         "simple-markdown": {
             "version": "0.7.2",
@@ -30,6 +1565,305 @@
             "requires": {
                 "@types/react": ">=16.0.0"
             }
+        },
+        "slice-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "standard": {
+            "version": "14.3.1",
+            "resolved": "https://registry.npmjs.org/standard/-/standard-14.3.1.tgz",
+            "integrity": "sha512-TUQwU7znlZLfgKH1Zwn/D84FitWZkUTfbxSiz/vFx+4c9GV+clSfG/qLiLZOlcdyzhw3oF5/pZydNjbNDfHPEw==",
+            "dev": true,
+            "requires": {
+                "eslint": "~6.4.0",
+                "eslint-config-standard": "14.1.0",
+                "eslint-config-standard-jsx": "8.1.0",
+                "eslint-plugin-import": "~2.18.0",
+                "eslint-plugin-node": "~10.0.0",
+                "eslint-plugin-promise": "~4.2.1",
+                "eslint-plugin-react": "~7.14.2",
+                "eslint-plugin-standard": "~4.0.0",
+                "standard-engine": "^12.0.0"
+            }
+        },
+        "standard-engine": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
+            "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
+            "dev": true,
+            "requires": {
+                "deglob": "^4.0.0",
+                "get-stdin": "^7.0.0",
+                "minimist": "^1.1.0",
+                "pkg-conf": "^3.1.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "string.prototype.trimleft": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "strip-ansi": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^4.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                }
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "table": {
+            "version": "5.4.6",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+            "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
+            },
+            "dependencies": {
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                }
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "tslib": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+            "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "type-fest": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+            "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+            "dev": true
+        },
+        "uniq": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+            "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "v8-compile-cache": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+            "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+            "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^0.5.1"
+            }
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,9 @@
     "name": "react-native-easy-markdown",
     "version": "1.5.0",
     "description": "Simple & customizable React Native component to render Github-flavoured markdown using minimal native components.",
-    "main": "lib/index.js",
+    "main": "index.js",
     "repository": "https://github.com/TitanInvest/react-native-easy-markdown",
     "scripts": {
-        "build": "babel index.js styles.js Utils.js -d lib",
-        "prepare": "npm run build",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "keywords": [
@@ -18,17 +16,15 @@
     ],
     "contributors": [
         "Juuso Lappalainen",
-        "Zach Ivester <zach@titanvest.com>"
+        "Zach Ivester <zach@titanvest.com>",
+        "Gregor MacLennan <gmaclennan@gmail.com>"
     ],
     "license": "MIT",
     "dependencies": {
-        "simple-markdown": "^0.4.4"
+        "simple-markdown": "^0.7.2"
     },
     "peerDependencies": {
         "react-native": "*"
     },
-    "devDependencies": {
-        "babel-cli": "^6.26.0",
-        "babel-preset-react-native": "^4.0.1"
-    }
+    "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,33 @@
 {
-    "name": "react-native-easy-markdown",
-    "version": "1.5.0",
-    "description": "Simple & customizable React Native component to render Github-flavoured markdown using minimal native components.",
-    "main": "index.js",
-    "repository": "https://github.com/TitanInvest/react-native-easy-markdown",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "keywords": [
-        "react-native",
-        "native",
-        "markdown",
-        "parse",
-        "parser"
-    ],
-    "contributors": [
-        "Juuso Lappalainen",
-        "Zach Ivester <zach@titanvest.com>",
-        "Gregor MacLennan <gmaclennan@gmail.com>"
-    ],
-    "license": "MIT",
-    "dependencies": {
-        "simple-markdown": "^0.7.2"
-    },
-    "peerDependencies": {
-        "react-native": "*"
-    },
-    "devDependencies": {}
+  "name": "react-native-easy-markdown",
+  "version": "1.5.0",
+  "description": "Simple & customizable React Native component to render Github-flavoured markdown using minimal native components.",
+  "main": "index.js",
+  "repository": "https://github.com/TitanInvest/react-native-easy-markdown",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "standard"
+  },
+  "keywords": [
+    "react-native",
+    "native",
+    "markdown",
+    "parse",
+    "parser"
+  ],
+  "contributors": [
+    "Juuso Lappalainen",
+    "Zach Ivester <zach@titanvest.com>",
+    "Gregor MacLennan <gmaclennan@gmail.com>"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "simple-markdown": "^0.7.2"
+  },
+  "peerDependencies": {
+    "react-native": "*"
+  },
+  "devDependencies": {
+    "standard": "^14.3.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "use-memo-one": "^1.1.1"
   },
   "peerDependencies": {
-    "react-native": "*"
+    "react-native": "^0.59.0"
   },
   "devDependencies": {
     "standard": "^14.3.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "simple-markdown": "^0.7.2"
+    "simple-markdown": "^0.7.2",
+    "use-memo-one": "^1.1.1"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/styles.js
+++ b/styles.js
@@ -1,108 +1,108 @@
 const defaultStyles = {
-    block: {
-        marginBottom: 10,
-        flexWrap: 'wrap',
-        flexDirection: 'row'
-    },
-    blockQuote: {
-        borderLeftWidth: 5,
-        borderLeftColor: '#aaaaaa',
-        backgroundColor: '#cccccc',
-        paddingLeft: 10
-    },
-    h1: {
-        fontSize: 30,
-        marginTop: 20,
-        marginBottom: 8
-    },
-    h2: {
-        fontSize: 20,
-        marginTop: 16,
-        marginBottom: 8
-    },
-    h3: {
-        fontSize: 20,
-        marginTop: 16,
-        marginBottom: 8
-    },
-    h4: {
-        fontSize: 20,
-        marginTop: 16,
-        marginBottom: 8
-    },
-    h5: {
-        fontSize: 20,
-        marginTop: 12,
-        marginBottom: 6
-    },
-    h6: {
-        fontSize: 20,
-        marginTop: 12,
-        marginBottom: 6
-    },
-    hr: {
-        alignSelf: 'stretch',
-        height: 1,
-        backgroundColor: '#333333',
-        marginVertical: 8,
-    },
-    text: {
-        alignSelf: 'flex-start'
-    },
-    strong: {
-        fontWeight: 'bold',
-    },
-    em: {
-        fontStyle: 'italic',
-    },
-    del: {
-        textDecorationLine: 'line-through',
-    },
-    u: {
-        textDecorationLine: 'underline',
-    },
-    linkWrapper: {
-        alignSelf: 'flex-start',
-    },
-    link: {
-        textDecorationLine: 'underline',
-        alignSelf: 'flex-start'
-    },
-    list: {
-        marginBottom: 20
-    },
-    listItem: {
-        flexDirection: 'row',
-        justifyContent: 'flex-start',
-        alignItems: 'center',
-        marginVertical: 5,
-    },
-    listItemContent: {
-        flexDirection: 'row',
-        flexShrink: 1,
-        justifyContent: 'flex-start',
-        alignItems: 'flex-start',
-    },
-    listItemBullet: {
-        width: 4,
-        height: 4,
-        backgroundColor: 'black',
-        borderRadius: 2,
-        marginRight: 10,
-    },
-    listItemNumber: {
-        marginRight: 10
-    },
-    imageWrapper: {
-        flex: 1,
-        flexDirection: 'row',
-        justifyContent: 'flex-start'
-    },
-    image: {
-        flex: 1,
-        minWidth: 200,
-        height: 200
-    }
-};
+  block: {
+    marginBottom: 10,
+    flexWrap: 'wrap',
+    flexDirection: 'row'
+  },
+  blockQuote: {
+    borderLeftWidth: 5,
+    borderLeftColor: '#aaaaaa',
+    backgroundColor: '#cccccc',
+    paddingLeft: 10
+  },
+  h1: {
+    fontSize: 30,
+    marginTop: 20,
+    marginBottom: 8
+  },
+  h2: {
+    fontSize: 20,
+    marginTop: 16,
+    marginBottom: 8
+  },
+  h3: {
+    fontSize: 20,
+    marginTop: 16,
+    marginBottom: 8
+  },
+  h4: {
+    fontSize: 20,
+    marginTop: 16,
+    marginBottom: 8
+  },
+  h5: {
+    fontSize: 20,
+    marginTop: 12,
+    marginBottom: 6
+  },
+  h6: {
+    fontSize: 20,
+    marginTop: 12,
+    marginBottom: 6
+  },
+  hr: {
+    alignSelf: 'stretch',
+    height: 1,
+    backgroundColor: '#333333',
+    marginVertical: 8
+  },
+  text: {
+    alignSelf: 'flex-start'
+  },
+  strong: {
+    fontWeight: 'bold'
+  },
+  em: {
+    fontStyle: 'italic'
+  },
+  del: {
+    textDecorationLine: 'line-through'
+  },
+  u: {
+    textDecorationLine: 'underline'
+  },
+  linkWrapper: {
+    alignSelf: 'flex-start'
+  },
+  link: {
+    textDecorationLine: 'underline',
+    alignSelf: 'flex-start'
+  },
+  list: {
+    marginBottom: 20
+  },
+  listItem: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    marginVertical: 5
+  },
+  listItemContent: {
+    flexDirection: 'row',
+    flexShrink: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'flex-start'
+  },
+  listItemBullet: {
+    width: 4,
+    height: 4,
+    backgroundColor: 'black',
+    borderRadius: 2,
+    marginRight: 10
+  },
+  listItemNumber: {
+    marginRight: 10
+  },
+  imageWrapper: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-start'
+  },
+  image: {
+    flex: 1,
+    minWidth: 200,
+    height: 200
+  }
+}
 
-module.exports = defaultStyles;
+module.exports = defaultStyles


### PR DESCRIPTION
I updated this to use a function component, mainly for my own use, but leaving this here in case you want to want to update this library. This removes the deprecated `componentWillReceiveProps`. It depends on hooks, so will only work with `react-native@^0.59.0`. Also removes babel and compile step, since it's not needed for react-native use.