### PR TITLE
feat: Remove newlines in text blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ class Markdown extends Component {
             );
         } else {
             return (
-                <Text key={key} style={style}>{node}</Text>
+                <Text key={key} style={style}>{node.split('\n').join(' ')}</Text>
             );
         }
     }


### PR DESCRIPTION
Markdown ignores newlines in text blocks, but these are currently being rendered, e.g. the following text should be rendered as two paragraphs in markdown, but instead all the newlines are rendered:

```md
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
culpa qui officia deserunt mollit anim id est laborum.

Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium
doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia
consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque
porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci
velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
magnam aliquam quaerat voluptatem. 
```
