### PR TITLE
Add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,58 @@
+declare module 'react-native-easy-markdown' {
+  import React from 'react';
+  import { StyleProp, TextStyle, ViewProps, ViewStyle } from 'react-native';
+
+  export enum TextType {
+    h1 = 'h1',
+    h2 = 'h2',
+    h3 = 'h3',
+    h4 = 'h4',
+    h5 = 'h5',
+    h6 = 'h6',
+    strong = 'strong',
+    del = 'del',
+    em = 'em',
+    u = 'u',
+  };
+
+  interface IProps {
+    debug?: boolean;
+    parseInline?: boolean;
+    useDefaultStyles?: boolean;
+    renderImage?: (src: string, alt: string, title: string, key: string) => React.ReactNode;
+    renderLink?: (href: string, title: string, children: React.ReactNode, key: string, extraThing: boolean) => React.ReactNode;
+    renderListBullet?: (ordered: boolean, index: number) => React.ReactNode;
+    renderLine?: (key: string) => React.ReactNode;
+    renderText?: (children: React.ReactNode, key: string, extras: { styles: StyleProp<TextStyle> }, textType: TextType) => React.ReactNode;
+    renderBlockQuote?: (children: React.ReactNode, key: string) => React.ReactNode;
+    renderBlockText?: (children: React.ReactNode, key: string) => React.ReactNode;
+    renderBlock?: (children: React.ReactNode, key: string) => React.ReactNode;
+    markdownStyles?: {
+        block?: StyleProp<ViewStyle>;
+        blockQuote?: StyleProp<TextStyle>;
+        del?: StyleProp<TextStyle>;
+        em?: StyleProp<TextStyle>;
+        h1?: StyleProp<TextStyle>;
+        h2?: StyleProp<TextStyle>;
+        h3?: StyleProp<TextStyle>;
+        h4?: StyleProp<TextStyle>;
+        h5?: StyleProp<TextStyle>;
+        h6?: StyleProp<TextStyle>;
+        hr?: StyleProp<TextStyle>;
+        image?: StyleProp<TextStyle>;
+        imageWrapper?: StyleProp<ViewStyle>;
+        link?: StyleProp<TextStyle>;
+        linkWrapper?: StyleProp<TextStyle>;
+        list?: StyleProp<TextStyle>;
+        listItem?: StyleProp<TextStyle>;
+        listItemBullet?: StyleProp<TextStyle>;
+        listItemContent?: StyleProp<TextStyle>;
+        listItemNumber?: StyleProp<TextStyle>;
+        strong?: StyleProp<TextStyle>;
+        text?: StyleProp<TextStyle>;
+        u?: StyleProp<TextStyle>;
+    };
+  };
+
+  export default class Markdown extends React.Component<IProps & ViewProps> {}
+}


### PR DESCRIPTION
The types for this library got deleted between version 1.5.0 and 2.0.0. This PR adds them back. It is mostly based on @Jpunt 's PR for types in 1.5.0 and also includes new types for the new renderLine, renderText, renderBlockQuote, renderBlockText, renderBlock props in 2.0.0 